### PR TITLE
husky.install to look for .git/hooks folder in cwd

### DIFF
--- a/lib/husky/util/util.ex
+++ b/lib/husky/util/util.ex
@@ -79,7 +79,7 @@ defmodule Husky.Util do
   """
   def host_path do
     :husky
-    |> Application.get_env(:host_path, "../../")
+    |> Application.get_env(:host_path, File.cwd!)
     |> Path.expand()
   end
 

--- a/lib/husky/util/util.ex
+++ b/lib/husky/util/util.ex
@@ -79,7 +79,7 @@ defmodule Husky.Util do
   """
   def host_path do
     :husky
-    |> Application.get_env(:host_path, File.cwd!)
+    |> Application.get_env(:host_path, File.cwd!())
     |> Path.expand()
   end
 

--- a/lib/husky/util/util.ex
+++ b/lib/husky/util/util.ex
@@ -78,8 +78,11 @@ defmodule Husky.Util do
   See `config/test.exs` for an override example
   """
   def host_path do
-    :husky
-    |> Application.get_env(:host_path, File.cwd!())
+    'git rev-parse --show-toplevel'
+    |> :os.cmd()
+    |> (&Application.get_env(:husky, :host_path, &1)).()
+    |> to_string()
+    |> String.trim()
     |> Path.expand()
   end
 


### PR DESCRIPTION
To fix the below mentioned error

```
... running 'husky.install' task
** (RuntimeError) '/home/.git' directory does not exist. Try running $ git init
    lib/husky/task/install.ex:40: Mix.Tasks.Husky.Install.create_scripts/2
    (mix) lib/mix/task.ex:301: Mix.Task.run_task/3
    (mix) lib/mix/cli.ex:75: Mix.CLI.run_task/2
    (elixir) lib/code.ex:376: Code.require_file/2
```