### PR TITLE
improve experience running tests in docker

### DIFF
--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -37,8 +37,8 @@ defmodule Husky.TestHelper do
   @doc """
   Create a fake remote repository in dev/remote and configure
   the dev/sandbox repository to have dev/remote as an origin repository
-  add a test file, an initial commit, and push the commit to remote to 
-  make sure it is working 
+  add a test file, an initial commit, and push the commit to remote to
+  make sure it is working
   """
   def initialize_remote(host_path \\ Util.host_path()) do
     remote_dir = Path.expand("../remote", host_path)
@@ -66,6 +66,7 @@ defmodule Husky.TestHelper do
     git remote add origin #{remote_git_dir} && \
     touch dummy.txt && \
     git add dummy.txt && \
+    git config --local user.email "tester@husky-elixir.tld" && \
     git commit -am 'init commit' --no-verify && \
     git push --set-upstream origin master --no-verify
     """


### PR DESCRIPTION
I have been running tests in docker via:

```
docker run --rm -it -v $(pwd):/husky elixir:1.9.0 bash -c "mix local.hex --force && cd /husky && mix test"
```

This works well overall, but the remote repo initialization fails because the git config in the container does not have an email address specified, which causes the `git commit ...` command to fail.  (And of course, this causes some test failures because the remote repo is not available).  What do you think of adding this local git config to make sure that the test user can successfully set up the remote repo? 